### PR TITLE
Fix component.io packaging

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "version": "0.2.1",
   "main": "octo.js",
   "dependencies": {
-    "visionmedia/superagent": "*"
+    "visionmedia/superagent": "0.21.0"
   },
   "scripts": [
     "octo.js"

--- a/component.json
+++ b/component.json
@@ -1,8 +1,11 @@
 {
   "name": "octo",
   "version": "0.2.1",
-  "main": "index",
+  "main": "octo.js",
   "dependencies": {
-    "superagent": "https://raw.github.com/Caged/octo/master/examples/ven/superagent.js"
-  }
+    "visionmedia/superagent": "*"
+  },
+  "scripts": [
+    "octo.js"
+  ]
 }

--- a/octo.js
+++ b/octo.js
@@ -47,6 +47,9 @@
         var req = superagent[method](api.host() + path)
 
         var complete = function(res) {
+          if (pager._handledError) {
+            return;
+          }
           limit = ~~res.header['x-ratelimit-limit']
           remaining = ~~res.header['x-ratelimit-remaining']
 
@@ -60,6 +63,7 @@
         }
 
         req.on('error', function (err) {
+          pager._handledError = err;
           pager.trigger('error', err);
         });
 

--- a/octo.js
+++ b/octo.js
@@ -45,6 +45,10 @@
         var req = superagent[method](api.host() + path)
 
         var complete = function(err, res) {
+          if (err) {
+            pager.trigger('error', err)
+            return
+          }
           limit = ~~res.header['x-ratelimit-limit']
           remaining = ~~res.header['x-ratelimit-remaining']
 
@@ -54,7 +58,6 @@
 
           pager.trigger('end', res)
           if(res.ok)    pager.trigger('success', res)
-          if(res.error) pager.trigger('error', res)
         }
 
         if(token) req.set('Authorization', 'token ' + token)

--- a/octo.js
+++ b/octo.js
@@ -67,6 +67,7 @@
         req
           .set(headers)
           .query({page: page, per_page: perpage})
+          .timeout(3000)
           .send(params)
           .end(complete)
       }

--- a/octo.js
+++ b/octo.js
@@ -8,7 +8,7 @@
 
   if(typeof superagent === 'undefined' && require) {
     superagent = require('superagent');
-    if (process !== undefined &&  process.execPath and process.execPath.indexOf('node') !== -1) {
+    if (process !== undefined && process.execPath && process.execPath.indexOf('node') !== -1) {
       btoa = require('btoa');
     }
   }

--- a/octo.js
+++ b/octo.js
@@ -1,4 +1,3 @@
-
 /*!
  * octo.js
  * Copyright (c) 2012 Justin Palmer <justin@labratrevenge.com>
@@ -37,7 +36,9 @@
           perpage = 30,
           hasnext = false,
           hasprev = false,
-          headers = {},
+          headers = {
+            'User-Agent': 'Octo.js'
+          },
           callbacks = {}
 
       var request = function() {

--- a/octo.js
+++ b/octo.js
@@ -59,6 +59,10 @@
           if(res.error) pager.trigger('error', res)
         }
 
+        req.on('error', function (err) {
+          pager.trigger('error', err);
+        });
+
         if(token) req.set('Authorization', 'token ' + token)
 
         if(!token && username && password)

--- a/octo.js
+++ b/octo.js
@@ -44,7 +44,7 @@
       var request = function() {
         var req = superagent[method](api.host() + path)
 
-        var complete = function(res) {
+        var complete = function(err, res) {
           limit = ~~res.header['x-ratelimit-limit']
           remaining = ~~res.header['x-ratelimit-remaining']
 

--- a/octo.js
+++ b/octo.js
@@ -1,4 +1,3 @@
-
 /*!
  * octo.js
  * Copyright (c) 2012 Justin Palmer <justin@labratrevenge.com>
@@ -8,8 +7,10 @@
 (function() {
 
   if(typeof superagent === 'undefined' && require) {
-    superagent = require('superagent')
-    btoa = require('btoa')
+    superagent = require('superagent');
+    if (if process !== undefined &&  process.execPath and process.execPath.indexOf('node') !== -1) {
+      btoa = require('btoa');
+    }
   }
 
   var octo = {}

--- a/octo.js
+++ b/octo.js
@@ -226,7 +226,7 @@
     // Initializes a DELETE request to GitHub API v3
     // Returns a pager
     api.del = function(path, params) {
-      return new pager('delete', path, params)
+      return new pager('del', path, params)
     }
 
     // Returns the API rate limit as reported by GitHub

--- a/octo.js
+++ b/octo.js
@@ -225,7 +225,7 @@
 
     // Initializes a DELETE request to GitHub API v3
     // Returns a pager
-    api.delete = function(path, params) {
+    api.del = function(path, params) {
       return new pager('delete', path, params)
     }
 

--- a/octo.js
+++ b/octo.js
@@ -8,7 +8,7 @@
 
   if(typeof superagent === 'undefined' && require) {
     superagent = require('superagent');
-    if (process !== undefined && process.execPath && process.execPath.indexOf('node') !== -1) {
+    if (typeof process !== 'undefined' && process.execPath && process.execPath.indexOf('node') !== -1) {
       btoa = require('btoa');
     }
   }

--- a/octo.js
+++ b/octo.js
@@ -8,7 +8,7 @@
 
   if(typeof superagent === 'undefined' && require) {
     superagent = require('superagent');
-    if (if process !== undefined &&  process.execPath and process.execPath.indexOf('node') !== -1) {
+    if (process !== undefined &&  process.execPath and process.execPath.indexOf('node') !== -1) {
       btoa = require('btoa');
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "http://labratrevenge.com"
   },
   "dependencies": {
-    "superagent": "0.9.0",
+    "superagent": "0.18.0",
     "btoa": "*"
   },
 


### PR DESCRIPTION
This PR fixes packaging of Octo for [Component.io](http://component.io/), which enables dependents, like noflo-github work also in the browser. 

Attached, a screenshot of noflo-github components (powered by Octo) running in the browser:

![screenshot 2014-02-12 at 16 44 23](https://f.cloud.github.com/assets/3346/2150066/db447b9e-93fc-11e3-86e1-d5ea5c5caff4.png)
